### PR TITLE
fix(oauth2): override callback url to not include query string

### DIFF
--- a/lib/omniauth-spotify.rb
+++ b/lib/omniauth-spotify.rb
@@ -50,6 +50,11 @@ module OmniAuth
       def raw_info
         @raw_info ||= access_token.get('me').parsed
       end
+
+      def callback_url
+        full_host + script_name + callback_path
+      end
+
     end
   end
 end


### PR DESCRIPTION
Fixes #8 and removes need for workaround for #7 

This was a change introduced in omniauth-oauth2 1.4.0 that broke several strategies that depended on it.
