### PR TITLE
Fix typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ config.omniauth :spotify, keys.spotify['client_id'], keys.spotify['client_secret
 ## Forcing a Permission-Request Dialog
 
 If a user has given permission for an app to access a scope, that permission won't be asked again unless the user revokes access.
-In these cases, authorization sequences proceed without user interation.
+In these cases, authorization sequences proceed without user interaction.
 
 To force a permission dialog being shown to the user, which also makes it possible for them to switch Spotify accounts,
 set either `request.env['rack.session'][:ommiauth_spotify_force_approval?]` or `flash[:ommiauth_spotify_force_approval?]` (Rails apps only)
@@ -54,7 +54,7 @@ to a truthy value on the request that performs the Omniauth redirection.
 ## Auth Hash Schema
 
 * Authorization data is available in the `request.env['omniauth.auth'].credentials` -- a hash that also responds to
-the `token`, `refresh_token`, `expires_at`, and `expires` methods.
+the `token`, `refresh_token`, `expires_at`, and `expires?` methods.
 
 ```ruby
  {


### PR DESCRIPTION
Thanks Claudio for merging.

Rechecking, I found these typos in README.md.

Also, do you think setting a flash variable is the best way to force a permission dialog? The alternative is to add a parameter to the auth URL. e.g. `/auth/spotify/?show_dialog=true`.

These auth parameters are usually used to carry an application state through the authorization sequence on the redirect URL. However Spotify is one provider that requires the redirect URL sent in the request and callback phases to _exactly_ match, including the query string, so this gem's code doesn't include any auth parameters in the callback URL it sends. This makes auth parameters available to be used for another purpose, such as for additional authentication request parameters. So there's a trade-off between the neatness and framework-independence of the parameter approach and this approach's non-standard use of the auth query string.


